### PR TITLE
Have ActionMapper re-use previous workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 venv/
 __pycache__/
 *.egg-info/
+
+# saved api keys and other IBM Watson info
+toboggan/watson_api.json

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ $env:API_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 python -m toboggan.server
 ```
 
+Note: Exporting the `API_KEY` environment variable is only needed for the first
+run. Subsequent runs will use the API key and workspace ID saved in
+`toboggan/watson_api.json` (ignored by Git). When making changes to
+`actions.json`, delete `toboggan/watson_api.json` in order to generate a new
+workspace with the updated intents. When a new workspace is generated, it may
+take a while to train -- calls to `ActionMapper#map` will return `None` for all
+input until the training is complete.
+
 ## Team Members
 - JS Teoh
 - Tom Paoloni

--- a/toboggan/actions.py
+++ b/toboggan/actions.py
@@ -2,7 +2,6 @@
 import sys
 from dataclasses import dataclass
 from typing import Any
-import atexit
 import json
 from os import environ, path
 from datetime import datetime
@@ -11,17 +10,16 @@ from ibm_watson import AssistantV1
 
 class ActionMapper:
     def __init__(self):
-        self._assistant = AssistantV1(
-            version='2019-02-28',
-            iam_apikey=environ['API_KEY'],
-            url='https://gateway.watsonplatform.net/assistant/api'
-        )
-        self._workspace_id = self._assistant.create_workspace(
-            name='Toboggan',
-            description=f'Created at {datetime.strftime(datetime.now(),"%c")}',
-            intents=self.__class__.get_intents()
-        ).get_result()['workspace_id']
-        atexit.register(self.cleanup)
+        if ActionMapper.has_previous_workspace():
+            info = ActionMapper.get_api_and_workspace_info()
+            api_key = info['api_key']
+            self._assistant = ActionMapper.create_assistant(api_key)
+            self._workspace_id = info['workspace_id']
+        else:
+            api_key = environ['API_KEY']
+            self._assistant = ActionMapper.create_assistant(api_key)
+            self._workspace_id = ActionMapper.create_workspace(self._assistant)
+            ActionMapper.save_api_and_workspace_info(api_key, self._workspace_id)
 
     def map(self, input_string):
         result = self._assistant.message(
@@ -43,12 +41,54 @@ class ActionMapper:
         return vars(sys.modules[__name__])[action_class]()
 
     @staticmethod
-    def get_intents():
-        fil = path.join(path.abspath(path.dirname(__file__)), 'actions.json')
-        return json.loads(open(fil).read())['intents']
+    def has_previous_workspace():
+        file_path = path.join(ActionMapper.dir(), 'watson_api.json')
+        return path.exists(file_path)
 
-    def cleanup(self):
-        self._assistant.delete_workspace(workspace_id=self._workspace_id)
+    @staticmethod
+    def get_api_and_workspace_info():
+        return json.loads(open(ActionMapper.info_file_path()).read())
+
+    @staticmethod
+    def create_assistant(api_key):
+        return AssistantV1(
+            version='2019-02-28',
+            iam_apikey=api_key,
+            url='https://gateway.watsonplatform.net/assistant/api'
+        )
+
+    @staticmethod
+    def create_workspace(assistant):
+        return assistant.create_workspace(
+            name='Toboggan',
+            description=f'Created at {datetime.strftime(datetime.now(),"%c")}',
+            intents=ActionMapper.get_intents()
+        ).get_result()['workspace_id']
+
+    @staticmethod
+    def save_api_and_workspace_info(api_key, workspace_id):
+        info = {
+            'api_key': api_key,
+            'workspace_id': workspace_id
+        }
+        with open(ActionMapper.info_file_path(), mode='w') as info_file:
+            print(json.dumps(info, indent=2), file=info_file)
+
+    @staticmethod
+    def get_intents():
+        return json.loads(open(ActionMapper.intents_file_path()).read())['intents']
+
+    @staticmethod
+    def info_file_path():
+        return path.join(ActionMapper.dir(), 'watson_api.json')
+
+    @staticmethod
+    def intents_file_path():
+        return path.join(ActionMapper.dir(), 'actions.json')
+
+    @staticmethod
+    def dir():
+        return path.abspath(path.dirname(__file__))
 
 
 @dataclass


### PR DESCRIPTION
Fixes the problem of the new workspaces taking a while to train each
time. For now, have to manually delete and regenerate a workspace if
intents in toboggan/actions.json need to be updated -- may add an
environ variable to force an update later.